### PR TITLE
- Wrapped: use isArray() for checking handle type instead

### DIFF
--- a/main/spotify/wrapped.js
+++ b/main/spotify/wrapped.js
@@ -1955,7 +1955,7 @@ const wrapped = {
 		if (!_isFolder(path)) { _createFolder(path); }
 		return Promise.parallel(
 			tracksData,
-			(track) => this.getTrackImg(toType(track.handle) === 'FbMetadbHandle' ? track.handle : track.handle[0])
+			(track) => this.getTrackImg(isArray(track.handle) ? track.handle[0] : track.handle)
 				.then((artPromise) => {
 					if (artPromise.image) {
 						const imgPath = path + _asciify(sanitize(track.title)).replace(/ /g, '').slice(0, 10).toLowerCase() + '.jpg';


### PR DESCRIPTION
toType() returns "Object" on my setup. It seems unreliable. Using instanceof may work, but isArray() just works.